### PR TITLE
Fix muti-classes.dex situation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,4 @@
 # Android第三代壳
+
+修复了在小米3手机Android4.4上测试，存在多个classes.dex文件加载时，没有针对包名过滤的情况。
+在华为EMUI上Android6.0测试失败。由于存在odex优化。

--- a/app/src/main/cpp/native-lib.cpp
+++ b/app/src/main/cpp/native-lib.cpp
@@ -31,7 +31,7 @@ void* get_module_base(pid_t pid,const char* module_name){
     if (fp != NULL){
         while (fgets(line,sizeof(line),fp)){
 //            LOGD("%s",line);
-            if (strstr(line,module_name)){
+            if (strstr(line,module_name) && strstr(line, "com.example.instruction")){
                 pch=strtok(line,"-");
                 addr=strtoul(pch,NULL,16);
                 break;


### PR DESCRIPTION
In the maps, multi-packages' classes.dex are loaded. We should filter by package name.